### PR TITLE
Broadcast groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "async-trait"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,8 +1261,10 @@ dependencies = [
 name = "yrs-warp"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "futures-util",
  "lib0",
+ "log",
  "thiserror",
  "tokio",
  "warp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,6 @@ dependencies = [
  "async-trait",
  "futures-util",
  "lib0",
- "log",
  "thiserror",
  "tokio",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,3 @@ thiserror = "1.0"
 futures-util = "0.3"
 tokio = { version = "1.20", features = ["full"] }
 async-trait = "0.1"
-log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ warp = "0.3"
 thiserror = "1.0"
 futures-util = "0.3"
 tokio = { version = "1.20", features = ["full"] }
+async-trait = "0.1"
+log = "0.4"

--- a/README.md
+++ b/README.md
@@ -2,35 +2,58 @@
 
 This library is an extension over [Yjs](https://yjs.dev)/[Yrs](https://github.com/y-crdt/y-crdt) Conflict-Free Replicated Data Types (CRDT) message exchange protocol. It provides an utilities connect with Yjs web socket provider using Rust tokio's [warp](https://github.com/seanmonstar/warp) web server.
 
-### Basic example
+### Demo
+
+A working demo can be seen under [examples](./examples) subfolder. It integrates this library API with Code Mirror 6, enhancing it with collaborative rich text document editing capabilities.
+
+### Example
+
+In order to gossip updates between different web socket connection from the clients collaborating over the same logical document, a broadcast group can be used:
 
 ```rust
 #[tokio::main]
 async fn main() {
-    // We're using a single static document shared among all the peers.
     let awareness = Arc::new(RwLock::new(Awareness::new(Doc::new())));
+    // open a broadcast group that listens to awareness and document updates
+    // and has a pending message buffer of up to 32 updates
+    let bcast = Arc::new(BroadcastGroup::open(awareness.clone(), 32).await);
 
+    // pass dependencies to awareness and broadcast group to every new created connection
     let ws = warp::path("my-room")
         .and(warp::ws())
         .and(warp::any().map(move || awareness.clone()))
+        .and(warp::any().map(move || bcast.clone()))
         .and_then(ws_handler);
-
+    
     warp::serve(ws).run(([0, 0, 0, 0], 8000)).await;
 }
 
-async fn ws_handler(ws: Ws, awareness: Arc<RwLock<Awareness>>) -> Result<impl Reply, Rejection> {
-    Ok(ws.on_upgrade(move |socket| peer(socket, awareness)))
+async fn ws_handler(
+    ws: Ws,
+    awareness: AwarenessRef,
+    bcast: Arc<BroadcastGroup>,
+) -> Result<impl Reply, Rejection> {
+    Ok(ws.on_upgrade(move |socket| peer(socket, awareness, bcast)))
 }
 
-async fn peer(socket: WebSocket, awareness: Arc<RwLock<Awareness>>) {
-    let conn = WarpConn::new(awareness, socket);
-    match conn.await {
-        Ok(()) => println!("peer disconnected"),
-        Err(err) => eprintln!("peer error occurred: {}", err),
+async fn peer(ws: WebSocket, awareness: AwarenessRef, bcast: Arc<BroadcastGroup>) {
+    // create new web socket connection wrapper that communicates via y-sync protocol
+    let conn = WarpConn::new(awareness, ws);
+    // subscribe a new connection to the broadcast group
+    let sub = bcast.join(conn.inbox().clone());
+    select! {
+        res = sub => {
+            match res {
+                Ok(_) => println!("broadcasting for channel finished successfully"),
+                Err(e) => eprintln!("broadcasting for channel finished abruptly: {}", e),
+            }
+        }
+        res = conn => {
+            match res {
+                Ok(_) => println!("peer disconnected"),
+                Err(e) => eprintln!("peer error occurred: {}", e),
+            }
+        }
     }
 }
 ```
-
-### Demo
-
-A working demo can be seen under [examples](./examples) subfolder. It integrates this library API with Code Mirror 6, enhancing it with collaborative rich text document editing capabilities.

--- a/examples/code-mirror/frontend/index.js
+++ b/examples/code-mirror/frontend/index.js
@@ -24,7 +24,7 @@ export const userColor = usercolors[random.uint32() % usercolors.length]
 const doc = new Y.Doc()
 const ytext = doc.getText('codemirror')
 
-const provider = new WebsocketProvider('ws://localhost:8000', 'my-room', doc)
+const provider = new WebsocketProvider('ws://localhost:8000', 'my-room', doc, { disableBc: true })
 
 const undoManager = new Y.UndoManager(ytext)
 

--- a/examples/code-mirror/main.rs
+++ b/examples/code-mirror/main.rs
@@ -5,7 +5,8 @@ use warp::ws::{WebSocket, Ws};
 use warp::{Filter, Rejection, Reply};
 use yrs::Doc;
 use yrs_warp::awareness::{Awareness, AwarenessRef};
-use yrs_warp::ws::{BroadcastGroup, WarpConn};
+use yrs_warp::broadcast::BroadcastGroup;
+use yrs_warp::ws::WarpConn;
 
 const STATIC_FILES_DIR: &str = "examples/code-mirror/frontend/dist";
 
@@ -28,6 +29,8 @@ async fn main() {
         Arc::new(RwLock::new(Awareness::new(doc)))
     };
 
+    // open a broadcast group that listens to awareness and document updates
+    // and has a pending message buffer of up to 32 updates
     let bcast = Arc::new(BroadcastGroup::open(awareness.clone(), 32).await);
 
     let static_files = warp::get().and(warp::fs::dir(STATIC_FILES_DIR));

--- a/examples/code-mirror/main.rs
+++ b/examples/code-mirror/main.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
+use tokio::select;
 use tokio::sync::RwLock;
 use warp::ws::{WebSocket, Ws};
 use warp::{Filter, Rejection, Reply};
 use yrs::Doc;
-use yrs_warp::awareness::Awareness;
-use yrs_warp::ws::WarpConn;
-
-type AwarenessRef = Arc<RwLock<Awareness>>;
+use yrs_warp::awareness::{Awareness, AwarenessRef};
+use yrs_warp::ws::{BroadcastGroup, WarpConn};
 
 const STATIC_FILES_DIR: &str = "examples/code-mirror/frontend/dist";
 
@@ -29,11 +28,14 @@ async fn main() {
         Arc::new(RwLock::new(Awareness::new(doc)))
     };
 
+    let bcast = Arc::new(BroadcastGroup::open(awareness.clone(), 32).await);
+
     let static_files = warp::get().and(warp::fs::dir(STATIC_FILES_DIR));
 
     let ws = warp::path("my-room")
         .and(warp::ws())
         .and(warp::any().map(move || awareness.clone()))
+        .and(warp::any().map(move || bcast.clone()))
         .and_then(ws_handler);
 
     let routes = ws.or(static_files);
@@ -41,18 +43,29 @@ async fn main() {
     warp::serve(routes).run(([0, 0, 0, 0], 8000)).await;
 }
 
-async fn ws_handler(ws: Ws, awareness: AwarenessRef) -> Result<impl Reply, Rejection> {
-    Ok(ws.on_upgrade(move |socket| peer(socket, awareness)))
+async fn ws_handler(
+    ws: Ws,
+    awareness: AwarenessRef,
+    bcast: Arc<BroadcastGroup>,
+) -> Result<impl Reply, Rejection> {
+    Ok(ws.on_upgrade(move |socket| peer(socket, awareness, bcast)))
 }
 
-async fn peer(ws: WebSocket, awareness: AwarenessRef) {
+async fn peer(ws: WebSocket, awareness: AwarenessRef, bcast: Arc<BroadcastGroup>) {
     let conn = WarpConn::new(awareness, ws);
-    match conn.await {
-        Ok(()) => {
-            println!("peer disconnected");
+    let sub = bcast.join(conn.inbox().clone());
+    select! {
+        res = sub => {
+            match res {
+                Ok(_) => println!("broadcasting for channel finished successfully"),
+                Err(e) => eprintln!("broadcasting for channel finished abruptly: {}", e),
+            }
         }
-        Err(err) => {
-            eprintln!("peer error occurred: {}", err);
+        res = conn => {
+            match res {
+                Ok(_) => println!("peer disconnected"),
+                Err(e) => eprintln!("peer error occurred: {}", e),
+            }
         }
     }
 }

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -1,12 +1,17 @@
+use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::rc::{Rc, Weak};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use thiserror::Error;
-use tokio::sync::broadcast::Sender;
+use tokio::sync::RwLock;
 use yrs::block::ClientID;
 use yrs::updates::decoder::{Decode, Decoder};
 use yrs::updates::encoder::{Encode, Encoder};
 use yrs::Doc;
+
+pub type AwarenessRef = Arc<RwLock<Awareness>>;
 
 pub const OUTDATED_TIMEOUT: Duration = Duration::from_millis(3000);
 
@@ -28,7 +33,7 @@ pub struct Awareness {
     doc: Doc,
     states: HashMap<ClientID, String>,
     meta: HashMap<ClientID, MetaClientState>,
-    on_update: Option<Sender<Event>>,
+    on_update: Option<EventHandler<Event>>,
 }
 
 unsafe impl Send for Awareness {}
@@ -47,19 +52,13 @@ impl Awareness {
         }
     }
 
-    /// Creates a new instance of [Awareness] struct, which operates over a given document.
-    /// Awareness instance has full ownership of that document. If necessary it can be accessed
-    /// using either [Awareness::doc] or [Awareness::doc_mut] methods.
-    ///
-    /// This method accepts a sender channel, that is used to propagate any update events about
-    /// client changes detected as a result of modifying the awareness state.
-    pub fn with_observer(doc: Doc, on_update: Sender<Event>) -> Self {
-        Awareness {
-            doc,
-            on_update: Some(on_update),
-            states: HashMap::new(),
-            meta: HashMap::new(),
-        }
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    pub fn on_update<F>(&mut self, f: F) -> Subscription<Event>
+    where
+        F: Fn(&Awareness, &Event) -> () + 'static,
+    {
+        let eh = self.on_update.get_or_insert_with(EventHandler::default);
+        eh.subscribe(f)
     }
 
     /// Returns a read-only reference to an underlying [Doc].
@@ -100,14 +99,14 @@ impl Awareness {
         match self.states.entry(client_id) {
             Entry::Occupied(mut e) => {
                 e.insert(new);
-                if let Some(sender) = self.on_update.as_mut() {
-                    let _ = sender.send(Event::new(vec![], vec![client_id], vec![]));
+                if let Some(eh) = self.on_update.as_ref() {
+                    eh.trigger(self, &Event::new(vec![], vec![client_id], vec![]));
                 }
             }
             Entry::Vacant(e) => {
                 e.insert(new);
-                if let Some(sender) = self.on_update.as_mut() {
-                    let _ = sender.send(Event::new(vec![client_id], vec![], vec![]));
+                if let Some(eh) = self.on_update.as_ref() {
+                    eh.trigger(self, &Event::new(vec![client_id], vec![], vec![]));
                 }
             }
         }
@@ -117,9 +116,12 @@ impl Awareness {
     pub fn remove_state(&mut self, client_id: ClientID) {
         let prev_state = self.states.remove(&client_id);
         self.update_meta(client_id);
-        if let Some(sender) = self.on_update.as_mut() {
+        if let Some(eh) = self.on_update.as_ref() {
             if prev_state.is_some() {
-                let _ = sender.send(Event::new(Vec::default(), Vec::default(), vec![client_id]));
+                eh.trigger(
+                    self,
+                    &Event::new(Vec::default(), Vec::default(), vec![client_id]),
+                );
             }
         }
     }
@@ -244,9 +246,9 @@ impl Awareness {
             };
         }
 
-        if let Some(sender) = self.on_update.as_mut() {
+        if let Some(eh) = self.on_update.as_ref() {
             if !added.is_empty() || !updated.is_empty() || !removed.is_empty() {
-                let _ = sender.send(Event::new(added, updated, removed));
+                eh.trigger(self, &Event::new(added, updated, removed));
             }
         }
 
@@ -257,6 +259,60 @@ impl Awareness {
 impl Default for Awareness {
     fn default() -> Self {
         Awareness::new(Doc::new())
+    }
+}
+
+struct EventHandler<T> {
+    seq_nr: u32,
+    subscribers: Rc<RefCell<HashMap<u32, Box<dyn Fn(&Awareness, &T) -> ()>>>>,
+}
+
+impl<T> EventHandler<T> {
+    pub fn subscribe<F>(&mut self, f: F) -> Subscription<T>
+    where
+        F: Fn(&Awareness, &T) -> () + 'static,
+    {
+        let subscription_id = self.seq_nr;
+        self.seq_nr += 1;
+        {
+            let func = Box::new(f);
+            let mut subs = self.subscribers.borrow_mut();
+            subs.insert(subscription_id, func);
+        }
+        Subscription {
+            subscription_id,
+            subscribers: Rc::downgrade(&self.subscribers),
+        }
+    }
+
+    pub fn trigger(&self, awareness: &Awareness, arg: &T) {
+        let subs = self.subscribers.borrow();
+        for func in subs.values() {
+            func(awareness, arg);
+        }
+    }
+}
+
+impl<T> Default for EventHandler<T> {
+    fn default() -> Self {
+        EventHandler {
+            seq_nr: 0,
+            subscribers: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+}
+
+pub struct Subscription<T> {
+    subscription_id: u32,
+    subscribers: Weak<RefCell<HashMap<u32, Box<dyn Fn(&Awareness, &T) -> ()>>>>,
+}
+
+impl<T> Drop for Subscription<T> {
+    fn drop(&mut self) {
+        if let Some(subs) = self.subscribers.upgrade() {
+            let mut s = subs.borrow_mut();
+            s.remove(&self.subscription_id);
+        }
     }
 }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,0 +1,88 @@
+use crate::awareness;
+use crate::awareness::{Awareness, AwarenessRef, Event};
+use crate::sync::MSG_SYNC_UPDATE;
+use crate::ws::{Inbox, Message, MSG_SYNC};
+use lib0::encoding::Write;
+use tokio::spawn;
+use tokio::sync::broadcast::{channel, Receiver, Sender};
+use tokio::task::JoinHandle;
+use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
+
+/// A broadcast group can be used to propagate updates produced by yrs [yrs::Doc] and [Awareness]
+/// structures in a binary form that conforms to a y-sync protocol.
+///
+/// New receivers can subscribe to a broadcasting group via [BroadcastGroup::join] method.
+pub struct BroadcastGroup {
+    awareness_sub: awareness::Subscription<Event>,
+    doc_sub: yrs::Subscription<yrs::UpdateEvent>,
+    awareness_ref: AwarenessRef,
+    sender: Sender<Vec<u8>>,
+    receiver: Receiver<Vec<u8>>,
+}
+
+unsafe impl Send for BroadcastGroup {}
+unsafe impl Sync for BroadcastGroup {}
+
+impl BroadcastGroup {
+    pub async fn open(awareness_ref: AwarenessRef, capacity: usize) -> Self {
+        let (sender, receiver) = channel(capacity);
+        let (doc_sub, awareness_sub) = {
+            let mut awareness = awareness_ref.write().await;
+            let sink = sender.clone();
+            let doc_sub = awareness.doc_mut().observe_update_v1(move |_txn, u| {
+                // we manually construct msg here to avoid update data copying
+                let mut encoder = EncoderV1::new();
+                encoder.write_var(MSG_SYNC);
+                encoder.write_var(MSG_SYNC_UPDATE);
+                encoder.write_buf(&u.update);
+                let msg = encoder.to_vec();
+                if let Err(e) = sink.send(msg) {
+                    panic!("couldn't broadcast the document update: {}", e);
+                }
+            });
+            let sink = sender.clone();
+            let awareness_sub = awareness.on_update(move |awareness, e| {
+                let added = e.added();
+                let updated = e.updated();
+                let removed = e.removed();
+                let mut changed = Vec::with_capacity(added.len() + updated.len() + removed.len());
+                changed.extend_from_slice(added);
+                changed.extend_from_slice(updated);
+                changed.extend_from_slice(removed);
+
+                if let Ok(u) = awareness.update_with_clients(changed) {
+                    let msg = Message::Awareness(u).encode_v1();
+                    if let Err(e) = sink.send(msg) {
+                        panic!("couldn't broadcast awareness update: {}", e)
+                    }
+                }
+            });
+            (doc_sub, awareness_sub)
+        };
+        BroadcastGroup {
+            awareness_ref,
+            sender,
+            receiver,
+            awareness_sub,
+            doc_sub,
+        }
+    }
+
+    /// Subscribes a new BroadcastGroup gossip receiver. Returned join handle serves as a
+    /// subscription handler - dropping it will unsubscribe receiver from the group. It can also
+    /// finish abruptly if subscriber has been closed or couldn't propagate gossips for any reason.
+    pub fn join<I>(&self, mut subscriber: I) -> JoinHandle<Result<(), I::Error>>
+    where
+        I: Inbox<Item = Vec<u8>> + Send + Sync + 'static,
+    {
+        let mut receiver = self.sender.subscribe();
+        spawn(async move {
+            while let Ok(msg) = receiver.recv().await {
+                if let Err(e) = subscriber.send(msg).await {
+                    return Err(e);
+                }
+            }
+            Ok(())
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod awareness;
+pub mod broadcast;
 pub mod sync;
 pub mod ws;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -3,28 +3,28 @@ use yrs::updates::decoder::{Decode, Decoder};
 use yrs::updates::encoder::{Encode, Encoder};
 use yrs::StateVector;
 
-/// Core Yjs defines two message types:
-/// • YjsSyncStep1: Includes the State Set of the sending client. When received, the client should reply with YjsSyncStep2.
-/// • YjsSyncStep2: Includes all missing structs and the complete delete set. When received, the client is assured that it
-///   received all information from the remote client.
-///
-/// In a peer-to-peer network, you may want to introduce a SyncDone message type. Both parties should initiate the connection
-/// with SyncStep1. When a client received SyncStep2, it should reply with SyncDone. When the local client received both
-/// SyncStep2 and SyncDone, it is assured that it is synced to the remote client.
-///
-/// In a client-server model, you want to handle this differently: The client should initiate the connection with SyncStep1.
-/// When the server receives SyncStep1, it should reply with SyncStep2 immediately followed by SyncStep1. The client replies
-/// with SyncStep2 when it receives SyncStep1. Optionally the server may send a SyncDone after it received SyncStep2, so the
-/// client knows that the sync is finished.  There are two reasons for this more elaborated sync model: 1. This protocol can
-/// easily be implemented on top of http and websockets. 2. The server shoul only reply to requests, and not initiate them.
-/// Therefore it is necesarry that the client initiates the sync.
-///
-/// Construction of a message:
-/// [messageType : varUint, message definition..]
-///
-/// Note: A message does not include information about the room name. This must to be handled by the upper layer protocol!
-///
-/// stringify[messageType] stringifies a message definition (messageType is already read from the bufffer)
+// Core Yjs defines two message types:
+// • YjsSyncStep1: Includes the State Set of the sending client. When received, the client should reply with YjsSyncStep2.
+// • YjsSyncStep2: Includes all missing structs and the complete delete set. When received, the client is assured that it
+//   received all information from the remote client.
+//
+// In a peer-to-peer network, you may want to introduce a SyncDone message type. Both parties should initiate the connection
+// with SyncStep1. When a client received SyncStep2, it should reply with SyncDone. When the local client received both
+// SyncStep2 and SyncDone, it is assured that it is synced to the remote client.
+//
+// In a client-server model, you want to handle this differently: The client should initiate the connection with SyncStep1.
+// When the server receives SyncStep1, it should reply with SyncStep2 immediately followed by SyncStep1. The client replies
+// with SyncStep2 when it receives SyncStep1. Optionally the server may send a SyncDone after it received SyncStep2, so the
+// client knows that the sync is finished.  There are two reasons for this more elaborated sync model: 1. This protocol can
+// easily be implemented on top of http and websockets. 2. The server shoul only reply to requests, and not initiate them.
+// Therefore it is necesarry that the client initiates the sync.
+//
+// Construction of a message:
+// [messageType : varUint, message definition..]
+//
+// Note: A message does not include information about the room name. This must to be handled by the upper layer protocol!
+//
+// stringify[messageType] stringifies a message definition (messageType is already read from the bufffer)
 
 pub const MSG_SYNC_STEP_1: u8 = 0;
 pub const MSG_SYNC_STEP_2: u8 = 1;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -26,9 +26,9 @@ use yrs::StateVector;
 ///
 /// stringify[messageType] stringifies a message definition (messageType is already read from the bufffer)
 
-const MSG_SYNC_STEP_1: u8 = 0;
-const MSG_SYNC_STEP_2: u8 = 1;
-const MSG_SYNC_UPDATE: u8 = 2;
+pub const MSG_SYNC_STEP_1: u8 = 0;
+pub const MSG_SYNC_STEP_2: u8 = 1;
+pub const MSG_SYNC_UPDATE: u8 = 2;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Message {


### PR DESCRIPTION
Related to #1

This PR introduces the idea of `BroadcastGroup`s, which can be used as a gossip exchange hubs between web sockets communicating using y-sync binary protocol.