### PR TITLE
release v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "lib0"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb83a90e2a0beb4a6c5ffd6ddc24afab7b1340f5615d6050987f311e850724e2"
+checksum = "db088f7d98d549ba85e37d4d1909f7fbef5ec215938b8cc74c68758197867390"
 dependencies = [
  "thiserror",
 ]
@@ -1248,9 +1248,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "yrs"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd45a7bd25be78f285276a9054183e5b77cfcce79ecca1beebd0c8816bef32e1"
+checksum = "fd3ce14710ed995855c5fb6df36934678d5d6bcbbd093aa5c15fb2e860b2d4e1"
 dependencies = [
  "lib0",
  "rand 0.7.3",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "yrs-warp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs-warp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Yrs synchronization protocol using Warp web sockets"
 license = "MIT"
@@ -13,8 +13,8 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lib0 = "0.11"
-yrs = "0.11"
+lib0 = "0.12"
+yrs = "0.12"
 warp = "0.3"
 thiserror = "1.0"
 futures-util = "0.3"

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -438,13 +438,13 @@ mod test {
     fn awareness() -> Result<(), Box<dyn std::error::Error>> {
         let (s1, mut o_local) = channel(1);
         let mut local = Awareness::new(Doc::with_client_id(1));
-        let sub_local = local.on_update(move |_, e| {
+        let _sub_local = local.on_update(move |_, e| {
             s1.send(e.clone()).unwrap();
         });
 
         let (s2, mut o_remote) = channel(1);
         let mut remote = Awareness::new(Doc::with_client_id(2));
-        let sub_remote = local.on_update(move |_, e| {
+        let _sub_remote = local.on_update(move |_, e| {
             s2.send(e.clone()).unwrap();
         });
 

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -133,7 +133,7 @@ impl WarpConn {
                     }
                     true
                 }
-                Err(lib0::error::Error::EndOfBuffer) => false,
+                Err(lib0::error::Error::EndOfBuffer(_)) => false,
                 Err(error) => return Err(Error::DecodingError(error)),
             }
         } {}


### PR DESCRIPTION
- Updated yrs dependency: v0.11 -> v0.12
- Introduction of BroadcastGroup
- Introduction of Inbox trait (WarpConn now exposes API to send messages directly on demand)