### PR TITLE
Implement Into trait for Subscription

### DIFF
--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -9,7 +9,7 @@ use tokio::sync::RwLock;
 use yrs::block::ClientID;
 use yrs::updates::decoder::{Decode, Decoder};
 use yrs::updates::encoder::{Encode, Encoder};
-use yrs::Doc;
+use yrs::{Doc, SubscriptionId};
 
 /// Type alias over [Awareness] struct hidden behind Arc and read-write lock to provide safe
 /// multi-threaded support.
@@ -307,6 +307,14 @@ impl<T> Default for EventHandler<T> {
 pub struct Subscription<T> {
     subscription_id: u32,
     subscribers: Weak<RefCell<HashMap<u32, Box<dyn Fn(&Awareness, &T) -> ()>>>>,
+}
+
+impl<T> Into<SubscriptionId> for Subscription<T> {
+    fn into(self) -> SubscriptionId {
+        let id = self.subscription_id;
+        std::mem::forget(self);
+        id
+    }
 }
 
 impl<T> Drop for Subscription<T> {


### PR DESCRIPTION
This gives us feature parity with the Subscription implementation in `y-crdt/y-crdt`.

I wonder if it would be possible to create more shared structs between the `y-crdt` subprojects to make it easier to move structs (especially for language bindings). The implementation detail of `Subscription` in `y-crdt/yrs-warp` and `y-crdt/y-crdt` seems to be the same.

https://github.com/y-crdt/y-crdt/blob/12bb8cc8b7550e36b2f4513fb60b85f7632f132d/yrs/src/event.rs#L61-L67