### PR TITLE
release v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "yrs-warp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "lib0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs-warp"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Yrs synchronization protocol using Warp web sockets"
 license = "MIT"


### PR DESCRIPTION
- updated to `y-sync` crate v0.3:
    - `BroadcastGroup` has been moved into `y-sync` crate.
    - `WarpConn` doesn't need to be created in order to serve incoming connections anymore.