### PR TITLE
Fixed setup for examples in readme

### DIFF
--- a/examples/code-mirror/README.md
+++ b/examples/code-mirror/README.md
@@ -4,13 +4,12 @@
 In order to generate static website content, first you need build it. This can be done via npm.
 
 ```bash
-npm i --global rollup
-
 cd examples/code-mirror/frontend
+npm install
 npm run build
 ```
 
-These commands will install and run [rollup.js](https://rollupjs.org/), which is used for bundling the JavaScript code and dependecies for Code Mirror.
+These commands will install all dependencies and run [rollup.js](https://rollupjs.org/), which is used for bundling the JavaScript code and dependecies for Code Mirror.
 
 Once the steps above are done, a `./frontent/dist` directory should appear. If so, all you need to do is to run following command from the *main git repository directory*:
 

--- a/examples/webrtc-signaling-server/README.md
+++ b/examples/webrtc-signaling-server/README.md
@@ -4,13 +4,12 @@
 In order to generate static website content, first you need build it. This can be done via npm.
 
 ```bash
-npm i --global rollup
-
 cd examples/webrtc-signaling-server/frontend
+npm install
 npm run build
 ```
 
-These commands will install and run [rollup.js](https://rollupjs.org/), which is used for bundling the JavaScript code and dependecies for Code Mirror.
+These commands will install all dependencies and run [rollup.js](https://rollupjs.org/), which is used for bundling the JavaScript code and dependecies for Code Mirror.
 
 Once the steps above are done, a `./frontent/dist` directory should appear. If so, all you need to do is to run following command from the *main git repository directory*:
 


### PR DESCRIPTION
For running the examples it is not enough to install rollup globally. The dependencies should be installed instead.

Instead of
```bash
npm i --global rollup
```
you should
```bash
npm install
```