### PR TITLE
Toggle connection by clicking on y-connect-btn

### DIFF
--- a/examples/code-mirror/frontend/index.js
+++ b/examples/code-mirror/frontend/index.js
@@ -46,3 +46,19 @@ const state = EditorState.create({
 })
 
 const view = new EditorView({ state, parent: document.querySelector('#editor') })
+
+// toggle connection by clicking on connect-btn
+const toggleButton = document.getElementById('y-connect-btn')
+let connected = true
+
+toggleButton.addEventListener('click', () => {
+    if (connected) {
+        provider.disconnect()
+        connected = false
+        toggleButton.innerText = 'Reconnect'
+    } else {
+        provider.connect()
+        connected = true
+        toggleButton.innerText = 'Disconnect'
+    }
+})

--- a/examples/webrtc-signaling-server/frontend/index.js
+++ b/examples/webrtc-signaling-server/frontend/index.js
@@ -46,3 +46,19 @@ const state = EditorState.create({
 })
 
 const view = new EditorView({ state, parent: document.querySelector('#editor') })
+
+// toggle connection by clicking on connect-btn
+const toggleButton = document.getElementById('y-connect-btn')
+let connected = true
+
+toggleButton.addEventListener('click', () => {
+    if (connected) {
+        provider.disconnect()
+        connected = false
+        toggleButton.innerText = 'Reconnect'
+    } else {
+        provider.connect()
+        connected = true
+        toggleButton.innerText = 'Disconnect'
+    }
+})


### PR DESCRIPTION
Noticed while checking out the example projects that the "Disconnect" button had no functionality.  I added a very simple toggle behaviour to both examples.

```javascript
// toggle connection by clicking on connect-btn
const toggleButton = document.getElementById('y-connect-btn')
let connected = true

toggleButton.addEventListener('click', () => {
    if (connected) {
        provider.disconnect()
        connected = false
        toggleButton.innerText = 'Reconnect'
    } else {
        provider.connect()
        connected = true
        toggleButton.innerText = 'Disconnect'
    }
})
```